### PR TITLE
Makefile: Use some common patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,31 @@
-OS_NAME := $(shell uname -s | tr A-Z a-z)
-EXEC = bin/LRez
-ifeq ($(OS_NAME),linux)
-        SHLIB_EXT=so
-else
-        SHLIB_EXT=dylib
+ifeq ($(SHLIB_EXT),)
+	OS_NAME := $(shell uname -s | tr A-Z a-z)
+	ifeq ($(OS_NAME),linux)
+		SHLIB_EXT=.so
+	else
+		SHLIB_EXT=.dylib
+	endif
 endif
 
 curDir = $(shell pwd)
-CC = g++
-CFLAGS  = -Wall -pedantic -O3 -m64 -shared -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++11 -fPIC
 
-BAMTOOLS_INC = $(curDir)/bamtools/include/bamtools/
-BAMTOOLS_LIB = $(curDir)/bamtools/lib/
+PREFIX ?= /usr/local
+BINDIR = $(PREFIX)/bin
+LIBDIR = $(PREFIX)/lib
 
-LREZ_INC = $(curDir)/src/include/
-LREZ_LIB = $(curDir)/lib/
+CXX ?= g++
+CXXFLAGS += -Wall -pedantic -O3 -m64 -std=c++11 -fPIC
+LDFLAGS += -L./lib -Wl,-rpath,$(LIBDIR) -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 
-LDFLAGS_BAMTOOLS = -lbamtools -L$(BAMTOOLS_LIB)
-LDFLAGS_LREZ = -llrez -L$(LREZ_LIB)
-LDFLAGS_BOOST_LZ_LM = -lboost_iostreams -lz -lm -lc
+BAMTOOLS_LIB_PREFIX = lrez_
+BAMTOOLS_LIB = lib/lib$(BAMTOOLS_LIB_PREFIX)bamtools$(SHLIB_EXT)
+
+BAMTOOLS_INC = ./include/bamtools/
+LREZ_INC = ./src/include/
+
+LIBS_LREZ = -llrez
+LIBS_BOOST_LZ_LM = -lboost_iostreams -lz -lm -lc
+LIBS_BAMTOOLS = -l$(BAMTOOLS_LIB_PREFIX)bamtools
 
 MAIN = src/main.o
 REVCOMP = src/reverseComplement.o
@@ -26,26 +33,45 @@ SOURCE = src/alignmentsRetrieval.o src/barcodesComparison.o src/barcodesExtracti
 SUBCOMMANDS = src/subcommands/compare.o src/subcommands/extract.o src/subcommands/help.o src/subcommands/indexBam.o src/subcommands/queryBam.o src/subcommands/indexFastq.o src/subcommands/queryFastq.o
 
 EXEC = bin/LRez
-LIB = lib/liblrez.${SHLIB_EXT}
+LIB = lib/liblrez${SHLIB_EXT}
 
-all: directories $(LIB) $(EXEC)
-
+all: $(LIB) $(EXEC)
 
 directories:
 	mkdir -p bin/ lib/
 
-$(LIB): $(SUBCOMMANDS) $(SOURCE) $(REVCOMP)
-	$(CC) -fPIC -shared -o $(LIB) $(SUBCOMMANDS) $(SOURCE) $(REVCOMP) $(LDFLAGS_BAMTOOLS) -Wl,-rpath,$(BAMTOOLS_LIB) $(LDFLAGS_BOOST_LZ_LM)
+$(BAMTOOLS_LIB):
+	mkdir -p bamtools/build
+	cd bamtools/build && \
+		cmake \
+			-DBUILD_SHARED_LIBS=ON \
+			-DCMAKE_SHARED_LIBRARY_PREFIX_CXX=lib$(BAMTOOLS_LIB_PREFIX) \
+			-DCMAKE_INSTALL_LIBDIR=lib \
+			-DCMAKE_INSTALL_PREFIX=$(curDir) \
+			.. && \
+		$(MAKE) -C src/api && \
+		cmake -DCMAKE_INSTALL_LOCAL_ONLY=1 -P src/cmake_install.cmake && \
+		cmake -P src/api/cmake_install.cmake
 
-$(EXEC): $(MAIN) $(LIB)
-	$(CC) -o $(EXEC) $(MAIN) $(LDFLAGS_LREZ) -Wl,-rpath,$(LREZ_LIB) $(LDFLAGS_BAMTOOLS) -Wl,-rpath,$(BAMTOOLS_LIB) $(LDFLAGS_BOOST_LZ_LM)
+$(LIB): $(SUBCOMMANDS) $(SOURCE) $(REVCOMP) $(BAMTOOLS_LIB) directories
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -o $(LIB) $(SUBCOMMANDS) $(SOURCE) $(REVCOMP) $(LIBS_BAMTOOLS) $(LIBS_BOOST_LZ_LM)
 
-src/%.o: src/%.cpp
-	$(CC) -o $@ -c $< $(CFLAGS) -I$(BAMTOOLS_INC) -I$(LREZ_INC)
+$(EXEC): $(MAIN) $(LIB) directories
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o $(EXEC) $(MAIN) $(LIBS_LREZ) $(LIBS_BAMTOOLS) $(LIBS_BOOST_LZ_LM)
+
+src/%.o: src/%.cpp $(BAMTOOLS_LIB)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I$(BAMTOOLS_INC) -I$(LREZ_INC) -o $@ -c $<
 
 src/reverseComplement.o: src/reverseComplement.cpp
-	$(CC) -o src/reverseComplement.o -c src/reverseComplement.cpp $(CFLAGS) -I$(LREZ_INC)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -I$(LREZ_INC) -o src/reverseComplement.o -c src/reverseComplement.cpp
 
+
+install: $(EXEC) $(LIB)
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(LIBDIR)
+	cp -a $(EXEC) $(DESTDIR)$(BINDIR)/
+	cp -a $(LIB)* $(DESTDIR)$(LIBDIR)/
+	cp -a $(BAMTOOLS_LIB)* $(DESTDIR)$(LIBDIR)/
 
 clean:
 	rm src/*.o src/subcommands/*.o $(EXEC) $(LIB)

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,8 @@ $(BAMTOOLS_LIB):
 			-DCMAKE_INSTALL_LIBDIR=lib \
 			-DCMAKE_INSTALL_PREFIX=$(curDir) \
 			.. && \
-		$(MAKE) -C src/api && \
-		cmake -DCMAKE_INSTALL_LOCAL_ONLY=1 -P src/cmake_install.cmake && \
-		cmake -P src/api/cmake_install.cmake
+		$(MAKE) && \
+		$(MAKE) install
 
 $(LIB): $(SUBCOMMANDS) $(SOURCE) $(REVCOMP) $(BAMTOOLS_LIB) directories
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -o $(LIB) $(SUBCOMMANDS) $(SOURCE) $(REVCOMP) $(LIBS_BAMTOOLS) $(LIBS_BOOST_LZ_LM)

--- a/install.sh
+++ b/install.sh
@@ -2,19 +2,4 @@
 
 set -e
 
-# Install bamtools
-cd bamtools
-mkdir -p build
-cd build
-cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=$PWD/../ ..
-make
-make install
-cd ../
-if [ -d "lib64" ]
-then
-	mv lib64 lib
-fi
-
-# Install LRez
-cd ../
-make
+make -j"$( nproc )" PREFIX="$( pwd )"


### PR DESCRIPTION
Hi @morispi,

here is the promised overhaul :).
I won't guarantee that it's the "very best practice" since I'm not a "veteran" with those Make builds (and bundling dependencies is usually finicky), but it follows some common pattern I've picked up over the years which should help building your software in a more standard way.

With this you can run `make PREFIX="$( pwd )` to get a similar behavior for you local build previously, and one can run `make && make install` to install it directly into `/usr/local` (or another prefix if the `PREFIX` environment variable is set).
I can explain some of those changes inline.