### PR TITLE
Enable building LRez with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+project(LRez CXX)
+set(CMAKE_CXX_STANDARD 11)
+
+find_package(Boost REQUIRED COMPONENTS iostreams)
+find_package(ZLIB REQUIRED)
+add_subdirectory(bamtools EXCLUDE_FROM_ALL)
+
+file(GLOB SRC_FILES src/*.cpp src/subcommands/*.cpp)
+add_executable(LRez ${SRC_FILES})
+target_include_directories(LRez PRIVATE src/include ${BamTools_SOURCE_DIR}/src)
+target_link_libraries(LRez BamTools Boost::iostreams ZLIB::ZLIB)


### PR DESCRIPTION
CMake gets a bit of a bad rep, but it makes building a project like this extremely easy on any platform.

You can now do 
```
mkdir build && cd build 
cmake -DCMAKE_INSTALL_PREFIX=prefix .. 
make
```
and it will work basically anywhere.

Hope this helps with the conda issue.