### PR TITLE
Remove any barcode integer suffix not just `-1`

### DIFF
--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -56,7 +56,7 @@ string retrieveNucleotidesContent(const string& barcode);
 	A barcode is considered as valid if it is not empty, if it does not contain any "N" for 10x and TELL-Seq,
 	if it is not "0_0_0" for stLFR data, and does not contain a "00" substring for Haplotagging data.
 	The function takes care of determining the employed sequencing technology.
-    It also removes the unwanted "-1" if it exsits at the end of the barcode.
+    It also removes the integer suffix, e.g. "-1", if it exsits at the end of the barcode.
 
 	@param barcode the barcode to verify
 	@throws runtime_error thrown if the sequencing technology could not be recognized

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -74,9 +74,10 @@ bool isValidBarcode(string& barcode) {
         return false;
     }
 
-    // first remove "-1" at the end of the barcode if exists
-    if (barcode.substr(barcode.length() - 2) == "-1"){
-        barcode = barcode.substr(0, barcode.length() - 2);
+    // first remove integer suffing, e.g. "-1", at the end of the barcode if exists
+    std::size_t found = barcode.find("-");
+    if (found != std::string::npos){
+        barcode = barcode.substr(0, found);
     }
 
     if (techno == Undefined) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -74,7 +74,7 @@ bool isValidBarcode(string& barcode) {
         return false;
     }
 
-    // first remove integer suffing, e.g. "-1", at the end of the barcode if exists
+    // first remove integer suffix, e.g. "-1", at the end of the barcode if exists
     std::size_t found = barcode.find("-");
     if (found != std::string::npos){
         barcode = barcode.substr(0, found);


### PR DESCRIPTION
Relates to #8 but does not solve the issue. This PR just makes it possible to use `LRez` with BAM/FASTQs with other suffixes than `-1`.